### PR TITLE
Fixes #4 - support max-len option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ marko-prettyprint src/ foo/
 marko-prettyprint template1.marko template2.marko
 ```
 
+The maximum line length (defaults to `80`) can be also be set:
+```
+marko-prettyprint . --syntax html --max-len 120
+```

--- a/src/PrintContext.js
+++ b/src/PrintContext.js
@@ -6,7 +6,7 @@ var SYNTAX_CONCISE = require('./constants').SYNTAX_CONCISE;
 var SYNTAX_HTML = require('./constants').SYNTAX_HTML;
 
 class PrintContext {
-    constructor(syntax, depth, indentString, preserveWhitespace) {
+    constructor(syntax, depth, indentString, preserveWhitespace, maxLen) {
         if (indentString == null) {
             indentString = '    ';
         }
@@ -15,6 +15,7 @@ class PrintContext {
         this.currentIndentString = getIndentString(depth, indentString);
         this.indentString = indentString;
         this.preserveWhitespace = preserveWhitespace === true;
+        this.maxLen = maxLen;
     }
 
     get isConciseSyntax() {
@@ -26,19 +27,19 @@ class PrintContext {
     }
 
     beginNested() {
-        return new PrintContext(this.syntax, this.depth+1, this.indentString, this.preserveWhitespace);
+        return new PrintContext(this.syntax, this.depth+1, this.indentString, this.preserveWhitespace, this.maxLen);
     }
 
     switchToHtmlSyntax() {
-        return new PrintContext(SYNTAX_HTML, this.depth, this.indentString, this.preserveWhitespace);
+        return new PrintContext(SYNTAX_HTML, this.depth, this.indentString, this.preserveWhitespace, this.maxLen);
     }
 
     startPreservingWhitespace() {
-        return new PrintContext(this.syntax, this.depth, this.indentString, true);
+        return new PrintContext(this.syntax, this.depth, this.indentString, true, this.maxLen);
     }
 
     clone() {
-        return new PrintContext(this.syntax, this.depth, this.indentString, this.preserveWhitespace);
+        return new PrintContext(this.syntax, this.depth, this.indentString, this.preserveWhitespace, this.maxLen);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,10 @@ module.exports = function prettyPrint(ast, userOptions) {
         SYNTAX_HTML;
 
     var indent = userOptions.indent || '    ';
+    var maxLen = userOptions['max-len'] || 80;
 
     // We always start out in the concise syntax
-    var printContext = new PrintContext(syntax, 0, indent);
+    var printContext = new PrintContext(syntax, 0, indent, false, maxLen);
     var writer = new Writer(0 /* col */);
 
     printers.printNodes(ast.body.items, printContext, writer);

--- a/src/printHtmlElement.js
+++ b/src/printHtmlElement.js
@@ -9,7 +9,6 @@ const formattingTags = require('./formatting-tags');
 const trim = require('./util/trim');
 
 const oldLiteralToString = require('marko/compiler/ast/Literal').prototype.toString;
-const MAX_COL = 80;
 
 function replaceEscapedNewLines(jsonString) {
     return jsonString.replace(/\\\\|\\n/g, (match) => {
@@ -54,6 +53,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
 
     var isDynamicTagName = node.tagName.startsWith('$');
     var preserveBodyWhitespace = printContext.preserveWhitespace === true;
+    var maxLen = printContext.maxLen;
 
     if (preserveBodyWhitespace || isDynamicTagName) {
         // We can only reliably preserve whitespace in HTML mode so we force the HTML
@@ -141,7 +141,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
                     }
                 }
 
-                if (i === 0 || writer.col + stringToAppend.length < MAX_COL) {
+                if (i === 0 || writer.col + stringToAppend.length < maxLen) {
                     writer.write(stringToAppend);
                 } else {
                     writer.write('\n' + printContext.currentIndentString + printContext.indentString + trim.ltrim(stringToAppend));
@@ -149,7 +149,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
             });
         } else {
             var attrsString = attrStringsArray.join('');
-            if (writer.col + attrsString.length < MAX_COL) {
+            if (writer.col + attrsString.length < maxLen) {
                 writer.write(attrsString);
             } else {
                 writer.write(' [\n');
@@ -185,7 +185,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
     if (bodyText && !hasLineBreaks(bodyText)) {
         let endCol = writer.col + bodyText.length + endTag.length;
 
-        if (endCol < MAX_COL) {
+        if (endCol < maxLen) {
             if (printContext.isConciseSyntax) {
                 writer.write(' - ' + bodyText);
             } else {

--- a/test/fixtures/autotest/max-line-length/expected.marko
+++ b/test/fixtures/autotest/max-line-length/expected.marko
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Marko Templating Engine</title>
+    </head>
+    <body>
+        <h1 class="super-duper-long__class-name--from-hell">Hello ${data.name}!</h1>
+        <h2 class="super-duper-long__class-name--from-hell another-super-duper-long__class-name--from-hell"
+            style="display: inline;">Hello ${data.name}!</h2>
+    </body>
+</html>
+
+~~~~~~~
+<!DOCTYPE html>
+html lang="en"
+    head
+        title - Marko Templating Engine
+    body
+        h1 class="super-duper-long__class-name--from-hell" - Hello ${data.name}!
+        h2 [
+                class="super-duper-long__class-name--from-hell another-super-duper-long__class-name--from-hell"
+                style="display: inline;"
+            ] - Hello ${data.name}!

--- a/test/fixtures/autotest/max-line-length/template.marko
+++ b/test/fixtures/autotest/max-line-length/template.marko
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Marko Templating Engine</title>
+    </head>
+    <body>
+        <h1 class="super-duper-long__class-name--from-hell">Hello ${data.name}!</h1>
+        <h2 class="super-duper-long__class-name--from-hell another-super-duper-long__class-name--from-hell" style="display: inline;">Hello ${data.name}!</h2>
+    </body>
+</html>

--- a/test/fixtures/autotest/max-line-length/test.js
+++ b/test/fixtures/autotest/max-line-length/test.js
@@ -1,0 +1,5 @@
+exports.getOptions = function() {
+    return {
+        'max-len': 120
+    };
+};


### PR DESCRIPTION
Adds a new command line option of `max-len` (this seems to be what eslint calls it). Let me know if any changes are needed.