### PR TITLE
add --max-len to binary args

### DIFF
--- a/bin/marko-prettyprint.js
+++ b/bin/marko-prettyprint.js
@@ -48,6 +48,10 @@ var args = require('argly').createParser({
         '--syntax -s': {
             type: 'string',
             description: 'The syntax (either "html" or "concise"). Defaults to "html"'
+        },
+        '--max-len': {
+            type: 'int',
+            description: 'The maximum line length. Defaults to 80'
         }
     })
     .usage('Usage: $0 <pattern> [options]')


### PR DESCRIPTION
Oops, the tests don't run through the binary. All args need to be listed there to be accepted.