### PR TITLE
fix max-len usage from binary

### DIFF
--- a/bin/marko-prettyprint.js
+++ b/bin/marko-prettyprint.js
@@ -84,6 +84,7 @@ var args = require('argly').createParser({
     .parse();
 
 var syntax = args.syntax || 'html';
+var maxLen = args.maxLen || 80;
 
 var ignoreRules = args.ignore;
 
@@ -203,6 +204,7 @@ var prettyprint = function(path, context) {
     var src = fs.readFileSync(path, { encoding: 'utf8' });
     var outputSrc = markoPrettyprint(src, {
         syntax: syntax,
+        maxLen: maxLen,
         filename: path
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ module.exports = function prettyPrint(ast, userOptions) {
         SYNTAX_HTML;
 
     var indent = userOptions.indent || '    ';
-    var maxLen = userOptions['max-len'] || 80;
+    var maxLen = userOptions.maxLen || 80;
 
     // We always start out in the concise syntax
     var printContext = new PrintContext(syntax, 0, indent, false, maxLen);

--- a/test/fixtures/autotest/max-line-length/expected.marko
+++ b/test/fixtures/autotest/max-line-length/expected.marko
@@ -4,8 +4,8 @@
         <title>Marko Templating Engine</title>
     </head>
     <body>
-        <h1 class="super-duper-long__class-name--from-hell">Hello ${data.name}!</h1>
-        <h2 class="super-duper-long__class-name--from-hell another-super-duper-long__class-name--from-hell"
+        <h1 class="super-duper-long__class-name">Hello ${data.name}!</h1>
+        <h2 class="super-duper-long__class-name" data-test="test attribute data" data-more="more attribute data"
             style="display: inline;">Hello ${data.name}!</h2>
     </body>
 </html>
@@ -16,8 +16,10 @@ html lang="en"
     head
         title - Marko Templating Engine
     body
-        h1 class="super-duper-long__class-name--from-hell" - Hello ${data.name}!
+        h1 class="super-duper-long__class-name" - Hello ${data.name}!
         h2 [
-                class="super-duper-long__class-name--from-hell another-super-duper-long__class-name--from-hell"
+                class="super-duper-long__class-name"
+                data-test="test attribute data"
+                data-more="more attribute data"
                 style="display: inline;"
             ] - Hello ${data.name}!

--- a/test/fixtures/autotest/max-line-length/template.marko
+++ b/test/fixtures/autotest/max-line-length/template.marko
@@ -4,7 +4,7 @@
         <title>Marko Templating Engine</title>
     </head>
     <body>
-        <h1 class="super-duper-long__class-name--from-hell">Hello ${data.name}!</h1>
-        <h2 class="super-duper-long__class-name--from-hell another-super-duper-long__class-name--from-hell" style="display: inline;">Hello ${data.name}!</h2>
+        <h1 class="super-duper-long__class-name">Hello ${data.name}!</h1>
+        <h2 class="super-duper-long__class-name" data-test="test attribute data" data-more="more attribute data" style="display: inline;">Hello ${data.name}!</h2>
     </body>
 </html>

--- a/test/fixtures/autotest/max-line-length/test.js
+++ b/test/fixtures/autotest/max-line-length/test.js
@@ -1,5 +1,5 @@
 exports.getOptions = function() {
     return {
-        'max-len': 120
+        maxLen: 120
     };
 };


### PR DESCRIPTION
Sorry about this... hopefully third time's the charm. Was a combination of using the code directly rather than through binary, and bad linking.

This PR pipes along the `--max-len` option (which turns into `maxLen`) to the binary file. I've also improved the tests to check more easily that it is managing the length correctly.