### PR TITLE
Valid JSON config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ _my-project/.marko-prettyprint:_
 ```json
 {
     "indent": "\t",
-    "syntax": "concise",    
+    "syntax": "concise"
 }
 ```
 


### PR DESCRIPTION
Trailing comma causing JSON parse error.

    Uncaught Error: Unable to parse JSON at path "...marko-prettyprint": SyntaxError: Unexpected token } in JSON