### PR TITLE
Switch to one attribute per line and remove extra parens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 node_js:
-- "4"
-- "5"
 - "6"
-- "7"
+- "8"
+- "10"
 language: node_js
 script: "npm test"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,18 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/node": {
-      "version": "7.0.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.48.tgz",
-      "integrity": "sha512-LLlXafM3BD52MH056tHxTXO8JFCnpJJQkdzIU3+m8ew+CXJY/5zIXgDNb4TK/QFvlI8QexLS5tL+sE0Qhegr1w=="
+    "@types/commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
+      "requires": {
+        "commander": "*"
+      }
+    },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "app-module-path": {
       "version": "2.2.0",
@@ -20,26 +28,21 @@
       "integrity": "sha1-KydORVGin/XnGZ0u2XiOtm7TbmA="
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-    },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -49,9 +52,9 @@
       "integrity": "sha1-jl/4R1/h1UHSroH3oa6gWuIaYhc="
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "chai": {
@@ -60,12 +63,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.5"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       },
       "dependencies": {
         "deep-eql": {
@@ -74,13 +77,13 @@
           "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
           "dev": true,
           "requires": {
-            "type-detect": "4.0.5"
+            "type-detect": "^4.0.0"
           }
         },
         "type-detect": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-          "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
           "dev": true
         }
       }
@@ -103,23 +106,20 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.2"
+        "glob": "^7.1.1"
       }
     },
     "commander": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.0.tgz",
-      "integrity": "sha512-0FAmW4svUhnHJzjJHrg0vHi8+3Wp5mqvZTOui03Tc0515CToaw1BD7WC8ROcY08UnTJJOr4essVYvXBSPYeV2w==",
-      "requires": {
-        "@types/node": "7.0.48"
-      }
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
     },
     "complain": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/complain/-/complain-1.2.0.tgz",
-      "integrity": "sha512-aP/MxFoYYVUZ8Xdih1vyaTSRiD99XLnlCloNre/UjFQFJkZ6YuMbGksi0jfxKeFOdlzm/6eE01vpJc99HiN/Mg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/complain/-/complain-1.3.0.tgz",
+      "integrity": "sha512-PA9uGpaS4BXKrhFx3rl2nZMWySnGoW1pWf+dpBqNdDx3uR6PA0EPxjD17H9OxvW5w/bODBSziQ516Guf59rW+w==",
       "requires": {
-        "error-stack-parser": "2.0.1"
+        "error-stack-parser": "^2.0.1"
       }
     },
     "concat-map": {
@@ -133,7 +133,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "core-util-is": {
@@ -187,9 +187,9 @@
       "resolved": "https://registry.npmjs.org/deresolve/-/deresolve-1.1.2.tgz",
       "integrity": "sha1-nPI3nI0tYx3EuZVylLkOSnLLbOA=",
       "requires": {
-        "lasso-package-root": "1.0.1",
-        "raptor-polyfill": "1.0.2",
-        "resolve-from": "1.0.1"
+        "lasso-package-root": "^1.0.0",
+        "raptor-polyfill": "^1.0.2",
+        "resolve-from": "^1.0.1"
       },
       "dependencies": {
         "resolve-from": {
@@ -200,9 +200,9 @@
       }
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dom-serializer": {
@@ -211,8 +211,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -241,7 +241,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -250,20 +250,21 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "editorconfig": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
-      "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.0.tgz",
+      "integrity": "sha512-j7JBoj/bpNzvoTQylfRZSc85MlLNKWQiq5y6gwKhmqD2h1eZ+tH4AXbkhEJD468gjDna/XMx2YtSkCxBRX9OGg==",
       "requires": {
-        "bluebird": "3.5.1",
-        "commander": "2.12.0",
-        "lru-cache": "3.2.0",
-        "semver": "5.4.1",
-        "sigmund": "1.0.1"
+        "@types/commander": "^2.11.0",
+        "@types/semver": "^5.4.0",
+        "commander": "^2.11.0",
+        "lru-cache": "^4.1.1",
+        "semver": "^5.4.1",
+        "sigmund": "^1.0.1"
       }
     },
     "entities": {
@@ -273,11 +274,11 @@
       "dev": true
     },
     "error-stack-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
-      "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
+      "integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
       "requires": {
-        "stackframe": "1.0.4"
+        "stackframe": "^1.0.4"
       }
     },
     "escape-string-regexp": {
@@ -287,15 +288,15 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -306,9 +307,9 @@
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "estraverse": {
       "version": "4.2.0",
@@ -330,7 +331,7 @@
       "resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
       "integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
       "requires": {
-        "chai": "3.5.0"
+        "chai": "^3.5.0"
       },
       "dependencies": {
         "chai": {
@@ -338,9 +339,9 @@
           "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
           "requires": {
-            "assertion-error": "1.0.2",
-            "deep-eql": "0.1.3",
-            "type-detect": "1.0.0"
+            "assertion-error": "^1.0.1",
+            "deep-eql": "^0.1.3",
+            "type-detect": "^1.0.0"
           }
         }
       }
@@ -374,24 +375,24 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "he": {
@@ -404,8 +405,8 @@
       "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.3.2.tgz",
       "integrity": "sha1-HMW/mCSgkcKIILM+r3gIOo6qhWw=",
       "requires": {
-        "char-props": "0.1.5",
-        "complain": "1.2.0"
+        "char-props": "^0.1.5",
+        "complain": "^1.0.0"
       }
     },
     "htmlparser2": {
@@ -414,11 +415,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       }
     },
     "indent-string": {
@@ -432,8 +433,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -454,14 +455,14 @@
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
-        "minimatch": "3.0.4",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "3.7.x",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
       },
       "dependencies": {
         "strip-json-comments": {
@@ -477,7 +478,7 @@
       "resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
       "integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
       "requires": {
-        "raptor-async": "1.1.3"
+        "raptor-async": "^1.1.2"
       }
     },
     "lasso-modules-client": {
@@ -485,8 +486,8 @@
       "resolved": "https://registry.npmjs.org/lasso-modules-client/-/lasso-modules-client-2.0.5.tgz",
       "integrity": "sha1-2aBnJKkAl3Y2lxZn7pwXDS/E3Sg=",
       "requires": {
-        "lasso-package-root": "1.0.1",
-        "raptor-polyfill": "1.0.2"
+        "lasso-package-root": "^1.0.0",
+        "raptor-polyfill": "^1.0.2"
       }
     },
     "lasso-package-root": {
@@ -494,7 +495,7 @@
       "resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
       "integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
       "requires": {
-        "lasso-caching-fs": "1.0.2"
+        "lasso-caching-fs": "^1.0.0"
       }
     },
     "levn": {
@@ -502,8 +503,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "listener-tracker": {
@@ -518,48 +519,50 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-      "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "1.0.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "marko": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/marko/-/marko-4.6.0.tgz",
-      "integrity": "sha512-4rTfOJWFuyqM/GuwGUf58NyK7ydyS6UeVhEk4C/WOMpcINUtXoSK7R9qeIKdoaDqL+AwccCtwVwHhBOf/Rkbqg==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/marko/-/marko-4.12.3.tgz",
+      "integrity": "sha512-JwbJf5/2swA8WvHwWJ6f/EQHttdtHYEJVax6Ut5xuejwnI7HzLyqPlJ7mQM6cb55NOl6MKq7vxTBh/OPjorrig==",
       "requires": {
-        "app-module-path": "2.2.0",
-        "argly": "1.2.0",
-        "browser-refresh-client": "1.1.4",
-        "char-props": "0.1.5",
-        "complain": "1.2.0",
-        "deresolve": "1.1.2",
-        "escodegen": "1.9.0",
-        "esprima": "4.0.0",
-        "estraverse": "4.2.0",
-        "events": "1.1.1",
-        "events-light": "1.0.5",
-        "he": "1.1.1",
-        "htmljs-parser": "2.3.2",
-        "lasso-caching-fs": "1.0.2",
-        "lasso-modules-client": "2.0.5",
-        "lasso-package-root": "1.0.1",
-        "listener-tracker": "2.0.0",
-        "minimatch": "3.0.4",
-        "object-assign": "4.1.1",
-        "property-handlers": "1.1.1",
-        "raptor-json": "1.1.0",
-        "raptor-polyfill": "1.0.2",
-        "raptor-promises": "1.0.3",
-        "raptor-regexp": "1.0.1",
-        "raptor-util": "3.2.0",
-        "resolve-from": "2.0.0",
-        "simple-sha1": "2.1.0",
-        "strip-json-comments": "2.0.1",
-        "try-require": "1.2.1",
-        "warp10": "1.3.6"
+        "app-module-path": "^2.2.0",
+        "argly": "^1.0.0",
+        "browser-refresh-client": "^1.0.0",
+        "char-props": "~0.1.5",
+        "complain": "^1.3.0",
+        "deresolve": "^1.1.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0",
+        "estraverse": "^4.2.0",
+        "events": "^1.0.2",
+        "events-light": "^1.0.0",
+        "he": "^1.1.0",
+        "htmljs-parser": "^2.3.2",
+        "lasso-caching-fs": "^1.0.1",
+        "lasso-modules-client": "^2.0.4",
+        "lasso-package-root": "^1.0.1",
+        "listener-tracker": "^2.0.0",
+        "minimatch": "^3.0.2",
+        "object-assign": "^4.1.0",
+        "property-handlers": "^1.0.0",
+        "raptor-json": "^1.0.1",
+        "raptor-polyfill": "^1.0.0",
+        "raptor-promises": "^1.0.1",
+        "raptor-regexp": "^1.0.0",
+        "raptor-util": "^3.2.0",
+        "resolve-from": "^2.0.0",
+        "shorthash": "0.0.2",
+        "simple-sha1": "^2.1.0",
+        "strip-json-comments": "^2.0.1",
+        "try-require": "^1.2.1",
+        "warp10": "^1.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -574,7 +577,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -593,27 +596,28 @@
       }
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
         "debug": "3.1.0",
-        "diff": "3.3.1",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
-        "growl": "1.10.3",
+        "growl": "1.10.5",
         "he": "1.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         }
       }
@@ -635,7 +639,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optionator": {
@@ -643,12 +647,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "path-is-absolute": {
@@ -669,9 +673,9 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prettier": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg=="
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w=="
     },
     "property-handlers": {
       "version": "1.1.1",
@@ -698,7 +702,7 @@
       "resolved": "https://registry.npmjs.org/raptor-json/-/raptor-json-1.1.0.tgz",
       "integrity": "sha1-cL0JsU5k99MuxQzOg3fWApwPCHY=",
       "requires": {
-        "raptor-strings": "1.0.2"
+        "raptor-strings": "^1.0.0"
       }
     },
     "raptor-polyfill": {
@@ -711,8 +715,8 @@
       "resolved": "https://registry.npmjs.org/raptor-promises/-/raptor-promises-1.0.3.tgz",
       "integrity": "sha1-1XaxEOBCNlT3/fFyHijULk3DwOs=",
       "requires": {
-        "q": "1.5.1",
-        "raptor-util": "1.1.2"
+        "q": "^1.0.1",
+        "raptor-util": "^1.0.0"
       },
       "dependencies": {
         "raptor-util": {
@@ -732,7 +736,7 @@
       "resolved": "https://registry.npmjs.org/raptor-strings/-/raptor-strings-1.0.2.tgz",
       "integrity": "sha1-ks4ssBU6/pBHDYA5oCVbTPM6tfw=",
       "requires": {
-        "raptor-polyfill": "1.0.2"
+        "raptor-polyfill": "^1.0.1"
       }
     },
     "raptor-util": {
@@ -746,10 +750,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "redent": {
@@ -757,24 +761,24 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "requires": {
-        "indent-string": "3.2.0",
-        "strip-indent": "2.0.0"
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "rusha": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.7.tgz",
-      "integrity": "sha1-MGc7fpX6/g6+H+JN1tlf1gX5Tt4="
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.13.tgz",
+      "integrity": "sha1-mghOe4YLF7/zAVuSxnpqM2GRUTo="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "shelljs": {
       "version": "0.3.0",
@@ -782,23 +786,28 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
+    "shorthash": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/shorthash/-/shorthash-0.0.2.tgz",
+      "integrity": "sha1-WbJo7sveWQOLMNogK8+93rLEpOs="
+    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "simple-sha1": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.0.tgz",
-      "integrity": "sha1-lCe7lv8SY8wQqEFM7dUaGLkZ6LM=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.1.tgz",
+      "integrity": "sha512-pFMPd+I/lQkpf4wFUeS/sED5IqdIG1lUlrQviBMV4u4mz8BRAcB5fvUx5Ckfg3kBigEglAjHg7E9k/yy2KlCqA==",
       "requires": {
-        "rusha": "0.8.7"
+        "rusha": "^0.8.1"
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "optional": true
     },
     "stackframe": {
@@ -823,12 +832,12 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "try-require": {
@@ -841,7 +850,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -864,6 +873,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,19 +27,19 @@
   },
   "homepage": "https://github.com/marko-js/marko-prettyprint/#readme",
   "dependencies": {
-    "argly": "^1.0.0",
+    "argly": "^1.2.0",
     "cssbeautify": "^0.3.1",
-    "editorconfig": "^0.13.2",
-    "lasso-package-root": "^1.0.0",
-    "marko": "^4.0.0",
-    "minimatch": "^3.0.0",
-    "prettier": "^1.8.2",
+    "editorconfig": "^0.15.0",
+    "lasso-package-root": "^1.0.1",
+    "marko": "^4.12.3",
+    "minimatch": "^3.0.4",
+    "prettier": "^1.13.7",
     "redent": "^2.0.0",
-    "resolve-from": "^3.0.0"
+    "resolve-from": "^4.0.0"
   },
   "devDependencies": {
-    "chai": "^4.0.0",
-    "jshint": "^2.9.1",
-    "mocha": "^4.0.0"
+    "chai": "^4.1.2",
+    "jshint": "^2.9.5",
+    "mocha": "^5.2.0"
   }
 }

--- a/src/util/formatJS.js
+++ b/src/util/formatJS.js
@@ -7,7 +7,8 @@ module.exports = function(code, printContext, indent) {
     printWidth: printContext.maxLen,
     singleQuote: printContext.singleQuote,
     useTabs: printContext.indentString[0] === '\t',
-    tabWidth: printContext.indentString.length
+    tabWidth: printContext.indentString.length,
+    parser: 'babylon'
   };
 
   if (code.slice(0, 5) === 'class') {

--- a/src/util/hasUnenclosedWhitespace.js
+++ b/src/util/hasUnenclosedWhitespace.js
@@ -1,0 +1,15 @@
+const WHITE_SPACE_EXPRESSION_TYPES = [
+  "LogicalExpression",
+  "AssignmentExpression",
+  "ConditionalExpression",
+  "BinaryExpression",
+  "NewExpression"
+];
+
+module.exports = function hasUnenclosedWhitespace(node) {
+  return (
+    node.value instanceof RegExp ||
+    node.toString().indexOf(" ") !== -1 &&
+    WHITE_SPACE_EXPRESSION_TYPES.indexOf(node.type) !== -1
+  );
+};

--- a/test/autotest/attr-array-literal/expected.marko
+++ b/test/autotest/attr-array-literal/expected.marko
@@ -1,0 +1,3 @@
+<div data-foo=[1, 2] data-bar=[1, 2]/>
+~~~~~~~
+div data-foo=[1, 2] data-bar=[1, 2]

--- a/test/autotest/attr-array-literal/template.marko
+++ b/test/autotest/attr-array-literal/template.marko
@@ -1,0 +1,3 @@
+<div data-foo=[1,2] data-bar=[1, 2]>
+
+</div>

--- a/test/autotest/attr-binary-expression/expected.marko
+++ b/test/autotest/attr-binary-expression/expected.marko
@@ -1,0 +1,3 @@
+<div data-foo=(a + b) data-bar=(a + b)/>
+~~~~~~~
+div data-foo=(a + b) data-bar=(a + b)

--- a/test/autotest/attr-binary-expression/template.marko
+++ b/test/autotest/attr-binary-expression/template.marko
@@ -1,0 +1,3 @@
+<div data-foo=a+b data-bar=(a + b)>
+
+</div>

--- a/test/autotest/attr-conditional-expression/expected.marko
+++ b/test/autotest/attr-conditional-expression/expected.marko
@@ -1,0 +1,3 @@
+<div data-foo=(a ? b : c) data-bar=(a ? b : c)/>
+~~~~~~~
+div data-foo=(a ? b : c) data-bar=(a ? b : c)

--- a/test/autotest/attr-conditional-expression/template.marko
+++ b/test/autotest/attr-conditional-expression/template.marko
@@ -1,0 +1,3 @@
+<div data-foo=a?b:c data-bar=(a ? b : c)>
+
+</div>

--- a/test/autotest/attr-logical-expression/expected.marko
+++ b/test/autotest/attr-logical-expression/expected.marko
@@ -1,0 +1,3 @@
+<div data-foo=(a || b) data-bar=(a || b)/>
+~~~~~~~
+div data-foo=(a || b) data-bar=(a || b)

--- a/test/autotest/attr-logical-expression/template.marko
+++ b/test/autotest/attr-logical-expression/template.marko
@@ -1,0 +1,3 @@
+<div data-foo=a||b data-bar=(a || b)>
+
+</div>

--- a/test/autotest/attr-object-literal/expected.marko
+++ b/test/autotest/attr-object-literal/expected.marko
@@ -1,0 +1,3 @@
+<div data-foo={a: 1, b: 2} data-bar={a: 1, b: 2}/>
+~~~~~~~
+div data-foo={a: 1, b: 2} data-bar={a: 1, b: 2}

--- a/test/autotest/attr-object-literal/template.marko
+++ b/test/autotest/attr-object-literal/template.marko
@@ -1,0 +1,3 @@
+<div data-foo={a:1,b:2} data-bar={ a: 1, b: 2 }>
+
+</div>

--- a/test/autotest/attr-regex-literal/expected.marko
+++ b/test/autotest/attr-regex-literal/expected.marko
@@ -1,0 +1,3 @@
+<div data-foo=(/abc/) data-bar=(/a bc/)/>
+~~~~~~~
+div data-foo=(/abc/) data-bar=(/a bc/)

--- a/test/autotest/attr-regex-literal/template.marko
+++ b/test/autotest/attr-regex-literal/template.marko
@@ -1,0 +1,3 @@
+<div data-foo=(/abc/) data-bar=(/a bc/)>
+
+</div>

--- a/test/autotest/attr-template-literal/expected.marko
+++ b/test/autotest/attr-template-literal/expected.marko
@@ -1,0 +1,3 @@
+<div data-foo=`bar` data-bar=tag`thing`/>
+~~~~~~~
+div data-foo=`bar` data-bar=tag`thing`

--- a/test/autotest/attr-template-literal/template.marko
+++ b/test/autotest/attr-template-literal/template.marko
@@ -1,0 +1,3 @@
+<div data-foo=`bar` data-bar=tag`thing`>
+
+</div>

--- a/test/autotest/attrs-multiline-nested/expected.marko
+++ b/test/autotest/attrs-multiline-nested/expected.marko
@@ -1,9 +1,17 @@
-<div data-foo="foo" data-bar="bar" data-hello="hello" data-world="world"
-    class="my-class" data-widget="my-really-awesome-weidget">
-    <div data-foo="foo" data-bar="bar" data-hello="hello" data-world="world"
-        class="my-class" data-widget="my-really-awesome-weidget">
-        Hello World
-    </div>
+<div
+    data-foo="foo"
+    data-bar="bar"
+    data-hello="hello"
+    data-world="world"
+    class="my-class"
+    data-widget="my-really-awesome-weidget">
+    <div
+        data-foo="foo"
+        data-bar="bar"
+        data-hello="hello"
+        data-world="world"
+        class="my-class"
+        data-widget="my-really-awesome-weidget">Hello World</div>
 </div>
 ~~~~~~~
 div [

--- a/test/autotest/attrs-multiline/expected.marko
+++ b/test/autotest/attrs-multiline/expected.marko
@@ -1,5 +1,10 @@
-<div data-foo="foo" data-bar="bar" data-hello="hello" data-world="world"
-    class="my-class" data-widget="my-really-awesome-weidget">Hello World</div>
+<div
+    data-foo="foo"
+    data-bar="bar"
+    data-hello="hello"
+    data-world="world"
+    class="my-class"
+    data-widget="my-really-awesome-weidget">Hello World</div>
 ~~~~~~~
 div [
         data-foo="foo"

--- a/test/autotest/attrs-over-80-chars/expected.marko
+++ b/test/autotest/attrs-over-80-chars/expected.marko
@@ -1,4 +1,5 @@
-<div data-widget="my-really-awesome-weidget-this-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going END"
+<div
+    data-widget="my-really-awesome-weidget-this-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going END"
     data-widget2="my-really-awesome-weidget-this-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going END"
     another-attribute="foo">
     <div data-widget="my-really-awesome-weidget-this-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going END">

--- a/test/autotest/max-line-length/expected.marko
+++ b/test/autotest/max-line-length/expected.marko
@@ -5,7 +5,10 @@
     </head>
     <body>
         <h1 class="super-duper-long__class-name">Hello ${data.name}!</h1>
-        <h2 class="super-duper-long__class-name" data-test="test attribute data" data-more="more attribute data"
+        <h2
+            class="super-duper-long__class-name"
+            data-test="test attribute data"
+            data-more="more attribute data"
             style="display: inline;">Hello ${data.name}!</h2>
     </body>
 </html>

--- a/test/autotest/var-array/expected.marko
+++ b/test/autotest/var-array/expected.marko
@@ -1,4 +1,5 @@
-<var classNames=["app-checkbox", state.checked && "checked", state.checkboxClassName]
+<var
+    classNames=["app-checkbox", state.checked && "checked", state.checkboxClassName]
     foo="bar"/>
 <app-button ref="button" class=classNames onClick('handleClick')>
     <span class="app-checkbox-icon"/>

--- a/test/marko-v3/autotest/attrs-multiline-nested/expected.marko
+++ b/test/marko-v3/autotest/attrs-multiline-nested/expected.marko
@@ -1,9 +1,17 @@
-<div data-foo="foo" data-bar="bar" data-hello="hello" data-world="world"
-    class="my-class" data-widget="my-really-awesome-weidget">
-    <div data-foo="foo" data-bar="bar" data-hello="hello" data-world="world"
-        class="my-class" data-widget="my-really-awesome-weidget">
-        Hello World
-    </div>
+<div
+    data-foo="foo"
+    data-bar="bar"
+    data-hello="hello"
+    data-world="world"
+    class="my-class"
+    data-widget="my-really-awesome-weidget">
+    <div
+        data-foo="foo"
+        data-bar="bar"
+        data-hello="hello"
+        data-world="world"
+        class="my-class"
+        data-widget="my-really-awesome-weidget">Hello World</div>
 </div>
 ~~~~~~~
 div [

--- a/test/marko-v3/autotest/attrs-multiline/expected.marko
+++ b/test/marko-v3/autotest/attrs-multiline/expected.marko
@@ -1,5 +1,10 @@
-<div data-foo="foo" data-bar="bar" data-hello="hello" data-world="world"
-    class="my-class" data-widget="my-really-awesome-weidget">Hello World</div>
+<div
+    data-foo="foo"
+    data-bar="bar"
+    data-hello="hello"
+    data-world="world"
+    class="my-class"
+    data-widget="my-really-awesome-weidget">Hello World</div>
 ~~~~~~~
 div [
         data-foo="foo"

--- a/test/marko-v3/autotest/attrs-over-80-chars/expected.marko
+++ b/test/marko-v3/autotest/attrs-over-80-chars/expected.marko
@@ -1,4 +1,5 @@
-<div data-widget="my-really-awesome-weidget-this-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going END"
+<div
+    data-widget="my-really-awesome-weidget-this-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going END"
     data-widget2="my-really-awesome-weidget-this-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going END"
     another-attribute="foo">
     <div data-widget="my-really-awesome-weidget-this-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going-keeps-going-and-going-and-going END">

--- a/test/marko-v3/autotest/max-line-length/expected.marko
+++ b/test/marko-v3/autotest/max-line-length/expected.marko
@@ -5,7 +5,10 @@
     </head>
     <body>
         <h1 class="super-duper-long__class-name">Hello ${data.name}!</h1>
-        <h2 class="super-duper-long__class-name" data-test="test attribute data" data-more="more attribute data"
+        <h2
+            class="super-duper-long__class-name"
+            data-test="test attribute data"
+            data-more="more attribute data"
             style="display: inline;">Hello ${data.name}!</h2>
     </body>
 </html>


### PR DESCRIPTION
This PR makes it so that when attributes break there is always one attribute per line (which is what most people would want).

Besides that it also fixes an issue where some expressions were needlessly wrapped multiple times with parentheses.

New snapshot tests are added an existing ones updated to reflect these changes.
