### PR TITLE
format CSS, Less and Sass code with prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,json,marko,yml}]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,11 +142,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cssbeautify": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
-      "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
-    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "homepage": "https://github.com/marko-js/marko-prettyprint/#readme",
   "dependencies": {
     "argly": "^1.2.0",
-    "cssbeautify": "^0.3.1",
     "editorconfig": "^0.15.0",
     "lasso-package-root": "^1.0.1",
     "marko": "^4.12.3",

--- a/src/printHtmlElement.js
+++ b/src/printHtmlElement.js
@@ -9,8 +9,7 @@ const Writer = require("./util/Writer");
 const formattingTags = require("./formatting-tags");
 
 const formatJS = require("./util/formatJS");
-const beautifyCSS = require("cssbeautify");
-const redent = require("redent");
+const formatStyles = require('./util/formatStyles');
 
 const codeTags = {
   class: {
@@ -26,7 +25,7 @@ const codeTags = {
     prettyprint: true
   },
   style: {
-    type: "css",
+    type: "style",
     prettyprint: true
   }
 };
@@ -67,17 +66,8 @@ function handleCodeTag(node, printContext, writer) {
       if (tagName === "static") {
         outputCode = "static " + outputCode;
       }
-    } else if (codeTagInfo.type === "css") {
-      let cssCodeStart = outputCode.indexOf("{");
-      let cssCodeEnd = outputCode.lastIndexOf("}");
-      let beforeCode = outputCode.substring(0, cssCodeStart);
-      let afterCode = outputCode.substring(cssCodeEnd);
-      let cssCode = outputCode.substring(cssCodeStart + 1, cssCodeEnd);
-      cssCode = beautifyCSS(cssCode, {
-        indent: printContext.indentString
-      });
-      cssCode = redent(cssCode, 1, printContext.indentString);
-      outputCode = beforeCode + "{\n" + cssCode + afterCode;
+    } else if (codeTagInfo.type === "style") {
+      outputCode = formatStyles(outputCode, printContext);
     }
   }
 

--- a/src/util/formatStyles.js
+++ b/src/util/formatStyles.js
@@ -1,0 +1,22 @@
+const format = require("prettier").format;
+
+module.exports = function(code, printContext) {
+    let parser;
+
+    const preprocessor = code.slice(6, 10);
+    if (preprocessor === 'scss') {
+        parser = 'scss';
+    } else if (preprocessor === 'less') {
+        parser = 'less';
+    } else {
+        parser = 'css';
+    }
+
+    const config = {
+        useTabs: printContext.indentString[0] === '\t',
+        tabWidth: printContext.indentString.length,
+        parser
+    };
+
+    return format(code, config);
+};

--- a/src/util/formatStyles.js
+++ b/src/util/formatStyles.js
@@ -1,16 +1,10 @@
 const format = require("prettier").format;
+const redent = require("redent");
 
 module.exports = function(code, printContext) {
-    let parser;
-
-    const preprocessor = code.slice(6, 10);
-    if (preprocessor === 'scss') {
-        parser = 'scss';
-    } else if (preprocessor === 'less') {
-        parser = 'less';
-    } else {
-        parser = 'css';
-    }
+    const matches = /^style(?:\.(\S+))?\s*\{\s*([\s\S]*)\s*\}\s*$/.exec(code);
+    const parser = matches[1] || 'css';
+    const block = matches[2];
 
     const config = {
         useTabs: printContext.indentString[0] === '\t',
@@ -18,5 +12,9 @@ module.exports = function(code, printContext) {
         parser
     };
 
-    return format(code, config);
+    code = format(block, config);
+
+    code = `style${parser === "css" ? "" : `.${parser}`} {\n${redent(code, 1, printContext.indentString)}}`;
+
+    return code;
 };

--- a/test/autotest/editorconfig/.editorconfig
+++ b/test/autotest/editorconfig/.editorconfig
@@ -1,5 +1,3 @@
-root = true
-
 [*.marko]
 indent_style = space
 indent_size = 8

--- a/test/autotest/style-less/expected.marko
+++ b/test/autotest/style-less/expected.marko
@@ -1,0 +1,25 @@
+style.less {
+    @my-ruleset: {
+        .my-selector {
+            @media tv {
+                background-color: black;
+            }
+        }
+    };
+    @media (orientation: portrait) {
+        @my-ruleset();
+    }
+}
+~~~~~~~
+style.less {
+    @my-ruleset: {
+        .my-selector {
+            @media tv {
+                background-color: black;
+            }
+        }
+    };
+    @media (orientation: portrait) {
+        @my-ruleset();
+    }
+}

--- a/test/autotest/style-less/template.marko
+++ b/test/autotest/style-less/template.marko
@@ -1,0 +1,12 @@
+style.less {
+    @my-ruleset: {
+    .my-selector {
+      @media tv {
+        background-color: black;
+      }
+    }
+  };
+@media (orientation:portrait) {
+    @my-ruleset();
+}
+}

--- a/test/autotest/style-sass/expected.marko
+++ b/test/autotest/style-sass/expected.marko
@@ -1,0 +1,45 @@
+style.scss {
+    @function color-yiq($color) {
+        $r: red($color);
+        $g: green($color);
+        $b: blue($color);
+
+        $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+
+        @if ($yiq >= $yiq-contrasted-threshold) {
+            @return $yiq-text-dark;
+        } @else {
+            @return $yiq-text-light;
+        }
+    }
+
+    @each $color, $value in $colors {
+        .swatch-#{$color} {
+            color: color-yiq($value);
+            background-color: #{$value};
+        }
+    }
+}
+~~~~~~~
+style.scss {
+    @function color-yiq($color) {
+        $r: red($color);
+        $g: green($color);
+        $b: blue($color);
+
+        $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+
+        @if ($yiq >= $yiq-contrasted-threshold) {
+            @return $yiq-text-dark;
+        } @else {
+            @return $yiq-text-light;
+        }
+    }
+
+    @each $color, $value in $colors {
+        .swatch-#{$color} {
+            color: color-yiq($value);
+            background-color: #{$value};
+        }
+    }
+}

--- a/test/autotest/style-sass/template.marko
+++ b/test/autotest/style-sass/template.marko
@@ -1,0 +1,20 @@
+style.scss {
+    @function color-yiq($color) {
+  $r: red($color);$g: green($color);$b: blue($color);
+
+  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+
+  @if ($yiq >= $yiq-contrasted-threshold) {
+    @return $yiq-text-dark;
+} @else {
+    @return $yiq-text-light;
+  }
+}
+
+@each $color, $value in $colors {
+  .swatch-#{$color} {
+    color: color-yiq($value);
+    background-color: #{$value};
+  }
+}
+}

--- a/test/autotest/style/template.marko
+++ b/test/autotest/style/template.marko
@@ -1,5 +1,3 @@
 style {
-    .foo {
-        background-color: red;
-    }
+    .foo { background-color: red; }
 }

--- a/test/marko-v3/package-lock.json
+++ b/test/marko-v3/package-lock.json
@@ -14,8 +14,8 @@
       "resolved": "https://registry.npmjs.org/async-writer/-/async-writer-2.1.3.tgz",
       "integrity": "sha1-XCo4B8u3GwfSXX4kAhMnKvAwoo8=",
       "requires": {
-        "complain": "1.2.0",
-        "events": "1.1.1"
+        "complain": "^1.0.0",
+        "events": "^1.0.2"
       }
     },
     "balanced-match": {
@@ -28,7 +28,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -47,7 +47,7 @@
       "resolved": "https://registry.npmjs.org/complain/-/complain-1.2.0.tgz",
       "integrity": "sha512-aP/MxFoYYVUZ8Xdih1vyaTSRiD99XLnlCloNre/UjFQFJkZ6YuMbGksi0jfxKeFOdlzm/6eE01vpJc99HiN/Mg==",
       "requires": {
-        "error-stack-parser": "2.0.1"
+        "error-stack-parser": "^2.0.1"
       }
     },
     "concat-map": {
@@ -60,9 +60,9 @@
       "resolved": "https://registry.npmjs.org/deresolve/-/deresolve-1.1.2.tgz",
       "integrity": "sha1-nPI3nI0tYx3EuZVylLkOSnLLbOA=",
       "requires": {
-        "lasso-package-root": "1.0.1",
-        "raptor-polyfill": "1.0.2",
-        "resolve-from": "1.0.1"
+        "lasso-package-root": "^1.0.0",
+        "raptor-polyfill": "^1.0.2",
+        "resolve-from": "^1.0.1"
       }
     },
     "error-stack-parser": {
@@ -70,7 +70,7 @@
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
       "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
       "requires": {
-        "stackframe": "1.0.4"
+        "stackframe": "^1.0.3"
       }
     },
     "esprima": {
@@ -88,8 +88,8 @@
       "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.3.2.tgz",
       "integrity": "sha1-HMW/mCSgkcKIILM+r3gIOo6qhWw=",
       "requires": {
-        "char-props": "0.1.5",
-        "complain": "1.2.0"
+        "char-props": "^0.1.5",
+        "complain": "^1.0.0"
       }
     },
     "lasso-caching-fs": {
@@ -97,7 +97,7 @@
       "resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
       "integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
       "requires": {
-        "raptor-async": "1.1.3"
+        "raptor-async": "^1.1.2"
       }
     },
     "lasso-package-root": {
@@ -105,7 +105,7 @@
       "resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
       "integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
       "requires": {
-        "lasso-caching-fs": "1.0.2"
+        "lasso-caching-fs": "^1.0.0"
       }
     },
     "marko": {
@@ -113,31 +113,31 @@
       "resolved": "https://registry.npmjs.org/marko/-/marko-3.14.3.tgz",
       "integrity": "sha1-DkDQc2gIQAAVBFswkJj+EGQwnRc=",
       "requires": {
-        "app-module-path": "1.1.0",
-        "async-writer": "2.1.3",
-        "browser-refresh-client": "1.1.4",
-        "char-props": "0.1.5",
-        "deresolve": "1.1.2",
-        "esprima": "2.7.3",
-        "events": "1.1.1",
-        "htmljs-parser": "2.3.2",
-        "lasso-package-root": "1.0.1",
-        "minimatch": "3.0.4",
-        "object-assign": "4.1.1",
-        "property-handlers": "1.1.1",
-        "raptor-args": "1.0.3",
-        "raptor-async": "1.1.3",
-        "raptor-json": "1.1.0",
-        "raptor-logging": "1.1.3",
-        "raptor-polyfill": "1.0.2",
-        "raptor-promises": "1.0.3",
-        "raptor-regexp": "1.0.1",
-        "raptor-renderer": "1.4.6",
-        "raptor-strings": "1.0.2",
-        "raptor-util": "2.0.1",
-        "resolve-from": "1.0.1",
-        "strip-json-comments": "2.0.1",
-        "try-require": "1.2.1"
+        "app-module-path": "^1.0.5",
+        "async-writer": "^2.0.0",
+        "browser-refresh-client": "^1.0.0",
+        "char-props": "~0.1.5",
+        "deresolve": "^1.0.0",
+        "esprima": "^2.7.0",
+        "events": "^1.0.2",
+        "htmljs-parser": "^2.2.1",
+        "lasso-package-root": "^1.0.0",
+        "minimatch": "^3.0.2",
+        "object-assign": "^4.1.0",
+        "property-handlers": "^1.0.0",
+        "raptor-args": "^1.0.0",
+        "raptor-async": "^1.1.2",
+        "raptor-json": "^1.0.1",
+        "raptor-logging": "^1.0.1",
+        "raptor-polyfill": "^1.0.0",
+        "raptor-promises": "^1.0.1",
+        "raptor-regexp": "^1.0.0",
+        "raptor-renderer": "^1.4.4",
+        "raptor-strings": "^1.0.0",
+        "raptor-util": "^2.0.1",
+        "resolve-from": "^1.0.0",
+        "strip-json-comments": "^2.0.1",
+        "try-require": "^1.2.1"
       }
     },
     "minimatch": {
@@ -145,7 +145,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "object-assign": {
@@ -178,7 +178,7 @@
       "resolved": "https://registry.npmjs.org/raptor-dom/-/raptor-dom-1.1.1.tgz",
       "integrity": "sha1-Xt4wpy3A+ZeiwXMfwfLESz+1rFo=",
       "requires": {
-        "raptor-pubsub": "1.0.5"
+        "raptor-pubsub": "^1.0.5"
       }
     },
     "raptor-json": {
@@ -186,7 +186,7 @@
       "resolved": "https://registry.npmjs.org/raptor-json/-/raptor-json-1.1.0.tgz",
       "integrity": "sha1-cL0JsU5k99MuxQzOg3fWApwPCHY=",
       "requires": {
-        "raptor-strings": "1.0.2"
+        "raptor-strings": "^1.0.0"
       }
     },
     "raptor-logging": {
@@ -194,8 +194,8 @@
       "resolved": "https://registry.npmjs.org/raptor-logging/-/raptor-logging-1.1.3.tgz",
       "integrity": "sha512-eklLyQmG5Y2oyIrSsvkFjBkjRYvwjemUQpQhjG757KKaNPxIPX9wu34bfQkIcS7OG495CP28CjX9baABLfOzIw==",
       "requires": {
-        "raptor-polyfill": "1.0.2",
-        "raptor-stacktraces": "1.0.1"
+        "raptor-polyfill": "^1.0.0",
+        "raptor-stacktraces": "^1.0.0"
       }
     },
     "raptor-polyfill": {
@@ -208,8 +208,8 @@
       "resolved": "https://registry.npmjs.org/raptor-promises/-/raptor-promises-1.0.3.tgz",
       "integrity": "sha1-1XaxEOBCNlT3/fFyHijULk3DwOs=",
       "requires": {
-        "q": "1.5.1",
-        "raptor-util": "1.1.2"
+        "q": "^1.0.1",
+        "raptor-util": "^1.0.0"
       },
       "dependencies": {
         "raptor-util": {
@@ -224,8 +224,8 @@
       "resolved": "https://registry.npmjs.org/raptor-pubsub/-/raptor-pubsub-1.0.5.tgz",
       "integrity": "sha1-Fe4SoOUFnsFbcv+dYeyvn0IS70c=",
       "requires": {
-        "events": "1.1.1",
-        "raptor-util": "1.1.2"
+        "events": "^1.0.2",
+        "raptor-util": "^1.0.0"
       },
       "dependencies": {
         "raptor-util": {
@@ -245,10 +245,10 @@
       "resolved": "https://registry.npmjs.org/raptor-renderer/-/raptor-renderer-1.4.6.tgz",
       "integrity": "sha1-bVMVhNHijyYAWba53TH/3rhH3eI=",
       "requires": {
-        "async-writer": "2.1.3",
-        "raptor-dom": "1.1.1",
-        "raptor-pubsub": "1.0.5",
-        "raptor-util": "1.1.2"
+        "async-writer": "^2.0.0",
+        "raptor-dom": "^1.0.0",
+        "raptor-pubsub": "^1.0.2",
+        "raptor-util": "^1.0.0"
       },
       "dependencies": {
         "raptor-util": {
@@ -268,7 +268,7 @@
       "resolved": "https://registry.npmjs.org/raptor-strings/-/raptor-strings-1.0.2.tgz",
       "integrity": "sha1-ks4ssBU6/pBHDYA5oCVbTPM6tfw=",
       "requires": {
-        "raptor-polyfill": "1.0.2"
+        "raptor-polyfill": "^1.0.1"
       }
     },
     "raptor-util": {


### PR DESCRIPTION
This PR makes it so that CSS, Less and Sass code in Marko is formatted using prettier.

New snapshot tests are added to reflect these changes.

Other changes:
- added a root level `.editorconfig`
- removed `cssbeautify`
- updated the `.editorconfig` in `test/autotest/editorconfig` and removed the `root = true`
- slightly obfuscated the `test/autotest/style/test.marko` to ensure that `prettier` formats it correctly