### PR TITLE
make config files' rules take precedence over defaults

### DIFF
--- a/bin/marko-prettyprint.js
+++ b/bin/marko-prettyprint.js
@@ -246,4 +246,3 @@ if (foundCount) {
 } else {
     console.log(`No templates found!`);
 }
-

--- a/src/prettyPrintAST.js
+++ b/src/prettyPrintAST.js
@@ -20,7 +20,7 @@ module.exports = function prettyPrintAST(ast, options) {
     if (filename) {
       var configFileOptions = readConfigFile(filename);
       if (configFileOptions) {
-        options = Object.assign({}, configFileOptions, options);
+        options = Object.assign({}, options, configFileOptions);
       }
     }
   }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,0 +1,2 @@
+# top-most EditorConfig file
+root = true

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,2 +1,3 @@
-# top-most EditorConfig file
+# for testing, overriding the rules in .editorconfig
+# at the root of this directory
 root = true

--- a/test/autotest/editorconfig/test.js
+++ b/test/autotest/editorconfig/test.js
@@ -1,0 +1,5 @@
+exports.getOptions = function() {
+    return {
+        indent: '  '
+    };
+};

--- a/test/autotest/marko-prettyprint-file/test.js
+++ b/test/autotest/marko-prettyprint-file/test.js
@@ -1,0 +1,5 @@
+exports.getOptions = function() {
+    return {
+        indent: '  '
+    };
+};


### PR DESCRIPTION
- make the rules from config files (set in `prettyPrintAST.js`) take precedence over the defaults (set in `/bin/marko-prettyprint.js`)
- update tests by adding a `test.js` setting `indent` but checking that the `.editorconfig` and `.marko-prettyprint` config files rule apply
- add a `.editorconfig` in `test/` with `root = true` to override all the rules from the `.editorconfig` in the root of the project

Ideally I feel, the precedence of rules should be set in one location instead of at 2 places and the precedence should be like so:
default rules < `.editorconfig` < `.marko-prettyprint` < CLI arguments
This will need additional work but this PR is a small step in that process.